### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ This is a TypeScript-based MCP server that provides DuckDuckGo search functional
 - Easy-to-use search tool interface
 - Rate limiting and error handling support
 
+<a href="https://glama.ai/mcp/servers/34fhy9xb9w">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/34fhy9xb9w/badge" alt="DuckDuckGo Server MCP server" />
+</a>
+
 ## Features
 
 ### Search Tool


### PR DESCRIPTION
This PR adds a badge for the [DuckDuckGo MCP Server](https://glama.ai/mcp/servers/34fhy9xb9w) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/34fhy9xb9w">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/34fhy9xb9w/badge" alt="DuckDuckGo Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.